### PR TITLE
docs: 补充 LLM 和 ASR 超时配置说明

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -64,6 +64,13 @@ Default profile:
 - model: `gpt-4o-mini-transcribe`
 - direct key field: `asr.api_key`
 - environment field: `OPENAI_API_KEY`
+- timeout field: `asr.timeout_seconds`, default `60`
+
+`asr.timeout_seconds` controls HTTP-based ASR requests, including `openai`,
+`doubao`, `sensevoice`, and `qwen3-asr-vllm`. Use a positive number of seconds.
+`0` or negative values fall back to the default `60` seconds. Increase it when a
+self-hosted ASR service needs more time for long recordings or first-token
+startup; lower it if you prefer faster failure on network issues.
 
 To switch to Doubao cloud ASR:
 
@@ -176,10 +183,14 @@ Notes:
 - model: `gpt-5.4-nano`
 - direct key field: `llm.api_key`
 - environment field: `OPENAI_API_KEY`
+- timeout field: `llm.timeout_seconds`, default `45`
 
 If you want to use the OpenAI Responses API instead, set `llm.endpoint_type` to `responses`.
 `llm.prompt` is also rendered as a Go `text/template` before it is used as correction instructions.
 `llm.prompt_file` works the same way and is preferred when you want the template outside YAML.
+`llm.timeout_seconds` controls the cleanup request timeout and its context
+deadline. Use a positive number of seconds. `0` or negative values fall back to
+the default `45` seconds.
 
 ### Personal Dictionary
 

--- a/docs/ja/configuration.md
+++ b/docs/ja/configuration.md
@@ -64,6 +64,13 @@ cp config.example.yaml ~/.config/coe/config.yaml
 - model: `gpt-4o-mini-transcribe`
 - 直接キーを書くフィールド: `asr.api_key`
 - 環境変数フィールド: `OPENAI_API_KEY`
+- タイムアウトフィールド: `asr.timeout_seconds`、デフォルトは `60`
+
+`asr.timeout_seconds` は HTTP ベースの ASR リクエストを制御します。対象は
+`openai`、`doubao`、`sensevoice`、`qwen3-asr-vllm` です。単位は秒で、正の値を
+指定してください。`0` または負の値はデフォルトの `60` 秒にフォールバックします。
+長い録音やセルフホスト ASR の初回起動に時間がかかる場合は大きくし、ネットワーク
+問題を早く失敗させたい場合は小さくします。
 
 Doubao クラウド ASR に切り替えるには:
 
@@ -176,10 +183,14 @@ asr:
 - model: `gpt-5.4-nano`
 - 直接キーを書くフィールド: `llm.api_key`
 - 環境変数フィールド: `OPENAI_API_KEY`
+- タイムアウトフィールド: `llm.timeout_seconds`、デフォルトは `45`
 
 OpenAI Responses API を使いたい場合は、`llm.endpoint_type` を `responses` にしてください。
 `llm.prompt` も Go の `text/template` としてレンダリングされたうえで補正指示に使われます。
 `llm.prompt_file` も同じ仕組みで、テンプレートを YAML の外に置きたい場合はこちらを優先してください。
+`llm.timeout_seconds` は LLM 整形リクエストの HTTP タイムアウトと context deadline を
+制御します。単位は秒で、正の値を指定してください。`0` または負の値はデフォルトの
+`45` 秒にフォールバックします。
 
 ### Personal Dictionary
 

--- a/docs/zh/configuration.md
+++ b/docs/zh/configuration.md
@@ -64,6 +64,12 @@ cp config.example.yaml ~/.config/coe/config.yaml
 - model：`gpt-4o-mini-transcribe`
 - 直接写 key 的字段：`asr.api_key`
 - 环境变量字段：`OPENAI_API_KEY`
+- 超时字段：`asr.timeout_seconds`，默认 `60`
+
+`asr.timeout_seconds` 控制基于 HTTP 的 ASR 请求，包括 `openai`、`doubao`、
+`sensevoice` 和 `qwen3-asr-vllm`。它的单位是秒，应该设成正数；`0` 或负数
+会回退到默认的 `60` 秒。如果自托管 ASR 服务处理长录音或冷启动较慢，可以调大；
+如果你希望网络问题更快失败，可以调小。
 
 如果你要切到豆包云端 ASR：
 
@@ -176,10 +182,13 @@ asr:
 - model：`gpt-5.4-nano`
 - 直接写 key 的字段：`llm.api_key`
 - 环境变量字段：`OPENAI_API_KEY`
+- 超时字段：`llm.timeout_seconds`，默认 `45`
 
 如果你想改走 OpenAI Responses API，可以把 `llm.endpoint_type` 设成 `responses`。
 `llm.prompt` 也会先按 Go `text/template` 渲染，再作为校正指令使用。
 `llm.prompt_file` 也是同样的机制；如果你想把模板放到 YAML 外面，优先用这个。
+`llm.timeout_seconds` 控制 LLM 校正请求的 HTTP 超时和 context deadline，单位是秒，
+应该设成正数；`0` 或负数会回退到默认的 `45` 秒。
 
 ### 个人词典
 


### PR DESCRIPTION
## 变更内容

- 补充 `asr.timeout_seconds` 的默认值、适用 provider 和取值行为
- 补充 `llm.timeout_seconds` 的默认值、HTTP timeout / context deadline 行为
- 同步更新英文、简体中文和日文配置文档

## 背景

PR #16 已经引入 LLM / ASR timeout 配置，但用户配置文档还没有说明这两个字段。

## 验证

- `GOCACHE=/tmp/coe-go-cache go test ./...`